### PR TITLE
Support Upper 1705 Creator Update

### DIFF
--- a/OptimizeSvchost/App.config
+++ b/OptimizeSvchost/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
 </configuration>

--- a/OptimizeSvchost/OptimizeSvchost.csproj
+++ b/OptimizeSvchost/OptimizeSvchost.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>OptimizeSvchost</RootNamespace>
     <AssemblyName>OptimizeSvchost</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <PublishUrl>publish\</PublishUrl>
@@ -26,6 +26,7 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/OptimizeSvchost/Program.cs
+++ b/OptimizeSvchost/Program.cs
@@ -13,7 +13,7 @@ namespace OptimizeSvchost
     {
         static String currentVersion;
 
-        static void JustWindows1709()
+        static void UpperWindows1709()
         {
             Console.WriteLine(@"==========================ERROR==============================");
             Console.WriteLine(@"=                                                           =");
@@ -56,9 +56,11 @@ namespace OptimizeSvchost
             {
                 RegistryKey regInfo = Registry.LocalMachine.OpenSubKey(registryPath, RegistryKeyPermissionCheck.ReadWriteSubTree);
                 regInfo.SetValue(@"SvcHostSplitThresholdInKB", value, RegistryValueKind.DWord);
+
                 Console.WriteLine("설정이 완료되었습니다: " + toHex(value));
                 Console.WriteLine("윈도우를 재시작하십시오.");
                 Console.ReadKey();
+
                 regInfo.Close();
             }
             catch (NullReferenceException ex)
@@ -83,7 +85,7 @@ namespace OptimizeSvchost
 
             if (!IsWindows10Creators())
             {
-                JustWindows1709();
+                UpperWindows1709();
                 return;
             }
 
@@ -127,11 +129,13 @@ namespace OptimizeSvchost
         static bool IsAdministrator()
         {
             WindowsIdentity windowsIdentity = WindowsIdentity.GetCurrent();
+
             if (windowsIdentity != null)
             {
                 WindowsPrincipal windowsPrincipal = new WindowsPrincipal(windowsIdentity);
                 return windowsPrincipal.IsInRole(WindowsBuiltInRole.Administrator);
             }
+
             return false;
         }
 
@@ -142,7 +146,8 @@ namespace OptimizeSvchost
             string path = @"SOFTWARE\Microsoft\Windows NT\CurrentVersion";
             string releaseId = Registry.LocalMachine.OpenSubKey(path).GetValue("ReleaseId").ToString();
             currentVersion = os.VersionString + releaseId;
-            if (releaseId == "1709")
+
+            if (Int32.Parse(releaseId) >= 1709)
                 return true;
             return false;
         }


### PR DESCRIPTION
Fixed #1 
.NET Framework 4.8 버전으로 고치고, 1709 버전 이상에서도 적절히 작동하는 것을 확인.
1903 버전까지 레지스트리 설정값 변경 사항 없음을 확인.